### PR TITLE
Use UTF-8 in base HTML template

### DIFF
--- a/share/jupyter/voila/templates/vuetify-base/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/vuetify-base/nbconvert_templates/voila.tpl
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/vue/2.6.10/vue.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/vuetify/2.0.17/vuetify.min.js"></script>
         <link href="https://cdnjs.cloudflare.com/ajax/libs/vuetify/2.0.17/vuetify.min.css" rel="stylesheet">


### PR DESCRIPTION
While I was editing my override of `app.html` in a project, I noticed that using a string like `Loading …` leads to it being displayed as `LoadingÂ â¦`, which is of course wrong.

The reason for that is that the base template doesn’t specify the character set, therefore the browser defaults to ISO-8859-1. This change fixes that.

It will break the encoding for users that are using legacy 8-bit charsets in their string outputs, but in 2019, I don’t see a reason to encourage that.